### PR TITLE
feat(trust): add Revettr as a trust scoring data source

### DIFF
--- a/packages/trust/src/__tests__/sources/revettr.test.ts
+++ b/packages/trust/src/__tests__/sources/revettr.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { queryRevettr } from "../../sources/revettr.js";
+
+function makeAttestResponse(overrides: {
+  score?: number;
+  tier?: "low" | "medium" | "high" | "critical";
+  flags?: string[];
+  omitFlags?: boolean;
+  jws?: string;
+  confidence?: number;
+  providerId?: string;
+  omitPayload?: boolean;
+  omitScore?: boolean;
+}) {
+  const payload: Record<string, unknown> = {
+    iss: "did:web:revettr.com",
+    sub: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+    iat: 1775881387,
+    exp: 1775884987,
+    category: "compliance_risk",
+    attestation_type: "compliance_risk",
+    tier: overrides.tier ?? "low",
+    confidence: 0.2,
+    signals: { domain: null, ip: null, sanctions: null, wallet: {} },
+    input_hash: "f442a24de50fa0174f0dd7549b9374be183603437d952fb5525b9e1163a6cbc1",
+    timestamp: "2026-04-11T04:23:07.645505+00:00",
+  };
+  if (!overrides.omitScore) {
+    payload.score = overrides.score ?? 97;
+  }
+  if (!overrides.omitFlags) {
+    payload.flags = overrides.flags ?? ["wallet_high_activity", "wallet_established"];
+  }
+
+  return {
+    ok: true,
+    json: async () => ({
+      "@context": ["https://www.w3.org/ns/credentials/v2"],
+      type: "TrustAttestation",
+      version: "1.0.0",
+      provider: {
+        id: overrides.providerId ?? "did:web:revettr.com",
+        category: "compliance_risk",
+      },
+      subject: { id: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045" },
+      attestation: overrides.omitPayload
+        ? undefined
+        : {
+            type: "ComplianceRiskAttestation",
+            confidence: overrides.confidence ?? 0.2,
+            payload,
+          },
+      jws: overrides.jws ?? "eyJhbGciOiJFUzI1NiJ9.payload.signature",
+      signature: "sig",
+      kid: "revettr-attest-v1",
+      algorithm: "ES256",
+      jwks_url: "https://revettr.com/.well-known/jwks.json",
+      revocations_url: "https://revettr.com/.well-known/revocations.json",
+    }),
+  };
+}
+
+describe("queryRevettr", () => {
+  const ORIG_API_KEY = process.env.REVETTR_API_KEY;
+  const ORIG_API_URL = process.env.REVETTR_API_URL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.REVETTR_API_KEY;
+    delete process.env.REVETTR_API_URL;
+  });
+
+  afterEach(() => {
+    if (ORIG_API_KEY !== undefined) process.env.REVETTR_API_KEY = ORIG_API_KEY;
+    if (ORIG_API_URL !== undefined) process.env.REVETTR_API_URL = ORIG_API_URL;
+  });
+
+  it("returns not-found when no input fields are provided", async () => {
+    const result = await queryRevettr({});
+    expect(result.found).toBe(false);
+    expect(result.score).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns not-found on fetch error", async () => {
+    mockFetch.mockRejectedValue(new Error("Network error"));
+    const result = await queryRevettr({ wallet: "0xabc" });
+    expect(result.found).toBe(false);
+    expect(result.score).toBe(0);
+  });
+
+  it("returns not-found on non-ok response", async () => {
+    mockFetch.mockResolvedValue({ ok: false, json: async () => ({}) });
+    const result = await queryRevettr({ wallet: "0xabc" });
+    expect(result.found).toBe(false);
+  });
+
+  it("returns not-found when attestation payload is missing", async () => {
+    mockFetch.mockResolvedValueOnce(makeAttestResponse({ omitPayload: true }));
+    const result = await queryRevettr({ wallet: "0xabc" });
+    expect(result.found).toBe(false);
+    expect(result.score).toBe(0);
+  });
+
+  it("returns not-found when payload score is missing", async () => {
+    mockFetch.mockResolvedValueOnce(makeAttestResponse({ omitScore: true }));
+    const result = await queryRevettr({ wallet: "0xabc" });
+    expect(result.found).toBe(false);
+  });
+
+  it("passes composite score through unchanged", async () => {
+    mockFetch.mockResolvedValueOnce(makeAttestResponse({ score: 73 }));
+    const result = await queryRevettr({ wallet: "0xabc" });
+    expect(result.found).toBe(true);
+    expect(result.score).toBe(73);
+  });
+
+  it("extracts tier, flags, jws, and provider metadata", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeAttestResponse({
+        score: 40,
+        tier: "high",
+        flags: ["sanctions_hit", "wallet_new"],
+        jws: "eyJhbGciOiJFUzI1NiJ9.custom.sig",
+        confidence: 0.85,
+      })
+    );
+    const result = await queryRevettr({ wallet: "0xabc", domain: "foo.com" });
+    expect(result.tier).toBe("high");
+    expect(result.flags).toEqual(["sanctions_hit", "wallet_new"]);
+    expect(result.jws).toBe("eyJhbGciOiJFUzI1NiJ9.custom.sig");
+    expect(result.kid).toBe("revettr-attest-v1");
+    expect(result.jwksUrl).toBe("https://revettr.com/.well-known/jwks.json");
+    expect(result.revocationsUrl).toBe("https://revettr.com/.well-known/revocations.json");
+    expect(result.issuerDid).toBe("did:web:revettr.com");
+    expect(result.attestationConfidence).toBeCloseTo(0.85);
+  });
+
+  it("clamps score into 0-100 range", async () => {
+    mockFetch.mockResolvedValueOnce(makeAttestResponse({ score: 150 }));
+    const tooHigh = await queryRevettr({ wallet: "0xabc" });
+    expect(tooHigh.score).toBe(100);
+
+    mockFetch.mockResolvedValueOnce(makeAttestResponse({ score: -10 }));
+    const tooLow = await queryRevettr({ wallet: "0xabc" });
+    expect(tooLow.score).toBe(0);
+  });
+
+  it("maps paycrow input field names to Revettr request body", async () => {
+    mockFetch.mockResolvedValueOnce(makeAttestResponse({ score: 50 }));
+    await queryRevettr({
+      wallet: "0xabc",
+      domain: "example.com",
+      ip: "1.2.3.4",
+      company: "Acme",
+    });
+
+    const call = mockFetch.mock.calls[0];
+    expect(call[0]).toBe("https://revettr.com/v1/attest");
+    const init = call[1];
+    expect(init.method).toBe("POST");
+    const parsedBody = JSON.parse(init.body);
+    expect(parsedBody.wallet_address).toBe("0xabc");
+    expect(parsedBody.domain).toBe("example.com");
+    expect(parsedBody.ip).toBe("1.2.3.4");
+    expect(parsedBody.company_name).toBe("Acme");
+  });
+
+  it("forwards REVETTR_API_KEY as x-api-key header when set", async () => {
+    process.env.REVETTR_API_KEY = "secret-key";
+    mockFetch.mockResolvedValueOnce(makeAttestResponse({ score: 50 }));
+
+    await queryRevettr({ wallet: "0xabc" });
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers["x-api-key"]).toBe("secret-key");
+  });
+
+  it("omits x-api-key header when REVETTR_API_KEY is unset", async () => {
+    mockFetch.mockResolvedValueOnce(makeAttestResponse({ score: 50 }));
+
+    await queryRevettr({ wallet: "0xabc" });
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers["x-api-key"]).toBeUndefined();
+  });
+
+  it("prefers explicit apiKey argument over env var", async () => {
+    process.env.REVETTR_API_KEY = "env-key";
+    mockFetch.mockResolvedValueOnce(makeAttestResponse({ score: 50 }));
+
+    await queryRevettr({ wallet: "0xabc" }, "arg-key");
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers["x-api-key"]).toBe("arg-key");
+  });
+
+  it("honors REVETTR_API_URL override", async () => {
+    process.env.REVETTR_API_URL = "https://staging.revettr.example";
+    mockFetch.mockResolvedValueOnce(makeAttestResponse({ score: 50 }));
+
+    await queryRevettr({ wallet: "0xabc" });
+    expect(mockFetch.mock.calls[0][0]).toBe("https://staging.revettr.example/v1/attest");
+  });
+
+  it("includes optional non-EVM wallet fields when provided", async () => {
+    mockFetch.mockResolvedValueOnce(makeAttestResponse({ score: 50 }));
+    await queryRevettr({
+      wallet: "0xabc",
+      solanaWallet: "SoLxxx",
+      xrplWallet: "rXxx",
+      bitcoinWallet: "bc1xxx",
+      stellarWallet: "GAxxx",
+    });
+
+    const parsedBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(parsedBody.solana_wallet).toBe("SoLxxx");
+    expect(parsedBody.xrpl_wallet).toBe("rXxx");
+    expect(parsedBody.bitcoin_wallet).toBe("bc1xxx");
+    expect(parsedBody.stellar_wallet).toBe("GAxxx");
+  });
+
+  it("returns empty flags array when flags field is missing", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeAttestResponse({ score: 80, omitFlags: true })
+    );
+    const result = await queryRevettr({ wallet: "0xabc" });
+    expect(result.flags).toEqual([]);
+  });
+});

--- a/packages/trust/src/index.ts
+++ b/packages/trust/src/index.ts
@@ -3,6 +3,7 @@ export { computeTrustScore, type CompositeTrustScore, type TrustEngineConfig, ty
 export { queryErc8004, type Erc8004Signal } from "./sources/erc8004.js";
 export { queryMoltbook, type MoltbookSignal } from "./sources/moltbook.js";
 export { queryBaseChain, type BaseChainSignal } from "./sources/base-chain.js";
+export { queryRevettr, type RevettrSignal, type RevettrTier, type RevettrQueryInput } from "./sources/revettr.js";
 export { startTrustServer, type TrustServerConfig } from "./server.js";
 export { registerAllTools, type ToolConfig } from "./tools.js";
 export { fetchWithRetry, type RetryOptions } from "./utils/retry.js";

--- a/packages/trust/src/sources/revettr.ts
+++ b/packages/trust/src/sources/revettr.ts
@@ -1,0 +1,212 @@
+/**
+ * Revettr API integration for agent trust scoring.
+ *
+ * Revettr is the compliance_risk issuer in the A2A #1734 Trust Evidence
+ * Format RFC. It covers the counterparty risk slot that no other agent
+ * trust provider fills:
+ *   - Sanctions screening (OFAC, EU, UN)
+ *   - Wallet reputation across multiple chains (Base, Ethereum, BSC,
+ *     Polygon, Arbitrum, plus extra chains via InsumerAPI enrichment)
+ *   - Domain hygiene (WHOIS, DNS, SSL)
+ *   - IP reputation (geolocation, VPN, datacenter detection)
+ *
+ * Calls POST ${REVETTR_API_URL}/v1/attest (free tier, 10 req/min per IP)
+ * which returns a signed JWS attestation envelope. We pass the composite
+ * 0-100 score straight through to the TrustSignal and surface tier and
+ * flags as typed fields for downstream consumers.
+ *
+ * Configuration:
+ *   REVETTR_API_URL — base URL override (default: https://revettr.com)
+ *   REVETTR_API_KEY — optional, forwarded as x-api-key header when set.
+ *                     Not required on the free tier today, forward
+ *                     compatible with a future paid or partner tier.
+ *
+ * Discovery doc: https://revettr.com/.well-known/risk-check.json
+ * JWKS:          https://revettr.com/.well-known/jwks.json
+ * DID:           did:web:revettr.com
+ * Algorithm:     ES256 (kid: revettr-attest-v1)
+ *
+ * The full JWS is attached to the returned signal so paycrow can verify
+ * it out of band against the published JWKS if stronger guarantees than
+ * the HTTPS channel to revettr.com are required.
+ */
+
+import { fetchWithRetry } from "../utils/retry.js";
+
+export type RevettrTier = "low" | "medium" | "high" | "critical";
+
+export interface RevettrSignal {
+  found: boolean;
+  /** Composite risk tier returned by Revettr */
+  tier: RevettrTier | null;
+  /** Risk indicator flags (e.g. wallet_established, sanctions_clear) */
+  flags: string[];
+  /** Full compact JWS (RFC 7515, ES256) for out-of-band verification */
+  jws: string | null;
+  /** Key ID from the attestation envelope */
+  kid: string | null;
+  /** JWKS URL published by Revettr for JWS verification */
+  jwksUrl: string | null;
+  /** Revocations list URL published by Revettr */
+  revocationsUrl: string | null;
+  /** Issuer DID (did:web:revettr.com) */
+  issuerDid: string | null;
+  /** Revettr's own confidence score for the attestation (0-1) */
+  attestationConfidence: number;
+  /** Normalized score 0-100 (pass-through from Revettr's composite score) */
+  score: number;
+}
+
+interface RevettrAttestationPayload {
+  iss?: string;
+  sub?: string;
+  iat?: number;
+  exp?: number;
+  category?: string;
+  attestation_type?: string;
+  score?: number;
+  tier?: RevettrTier;
+  confidence?: number;
+  flags?: string[];
+  signals?: Record<string, unknown>;
+  input_hash?: string;
+  timestamp?: string;
+}
+
+interface RevettrAttestation {
+  type?: string;
+  confidence?: number;
+  payload?: RevettrAttestationPayload;
+}
+
+interface RevettrProvider {
+  id?: string;
+  category?: string;
+}
+
+interface RevettrAttestResponse {
+  provider?: RevettrProvider;
+  attestation?: RevettrAttestation;
+  jws?: string;
+  signature?: string;
+  kid?: string;
+  algorithm?: string;
+  jwks_url?: string;
+  revocations_url?: string;
+}
+
+export interface RevettrQueryInput {
+  /** EVM wallet address (0x...) */
+  wallet?: string;
+  /** Counterparty domain */
+  domain?: string;
+  /** Counterparty IP address */
+  ip?: string;
+  /** Counterparty company name */
+  company?: string;
+  /** Optional non-EVM wallet addresses */
+  solanaWallet?: string;
+  xrplWallet?: string;
+  bitcoinWallet?: string;
+  stellarWallet?: string;
+}
+
+const DEFAULT_REVETTR_BASE_URL = "https://revettr.com";
+
+const NOT_FOUND: RevettrSignal = {
+  found: false,
+  tier: null,
+  flags: [],
+  jws: null,
+  kid: null,
+  jwksUrl: null,
+  revocationsUrl: null,
+  issuerDid: null,
+  attestationConfidence: 0,
+  score: 0,
+};
+
+/**
+ * Query Revettr for a counterparty risk attestation.
+ *
+ * At least one of wallet/domain/ip/company should be supplied. Revettr
+ * will run all applicable signal groups and return a signed attestation
+ * envelope with a composite 0-100 score plus tier and flags.
+ *
+ * Returns a not-found signal on any error (network failure, HTTP
+ * non-200, missing fields) so the trust engine can degrade gracefully.
+ */
+export async function queryRevettr(
+  input: RevettrQueryInput,
+  apiKey?: string
+): Promise<RevettrSignal> {
+  const key = apiKey ?? process.env.REVETTR_API_KEY;
+  const baseUrl = process.env.REVETTR_API_URL ?? DEFAULT_REVETTR_BASE_URL;
+
+  const body: Record<string, string> = {};
+  if (input.wallet) body.wallet_address = input.wallet;
+  if (input.domain) body.domain = input.domain;
+  if (input.ip) body.ip = input.ip;
+  if (input.company) body.company_name = input.company;
+  if (input.solanaWallet) body.solana_wallet = input.solanaWallet;
+  if (input.xrplWallet) body.xrpl_wallet = input.xrplWallet;
+  if (input.bitcoinWallet) body.bitcoin_wallet = input.bitcoinWallet;
+  if (input.stellarWallet) body.stellar_wallet = input.stellarWallet;
+
+  if (Object.keys(body).length === 0) {
+    return NOT_FOUND;
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+  if (key) {
+    headers["x-api-key"] = key;
+  }
+
+  try {
+    const res = await fetchWithRetry(
+      `${baseUrl}/v1/attest`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      },
+      { maxAttempts: 2, timeoutMs: 8000, baseDelayMs: 500 }
+    );
+
+    if (!res.ok) {
+      return NOT_FOUND;
+    }
+
+    const data = (await res.json()) as RevettrAttestResponse;
+    const payload = data?.attestation?.payload;
+
+    if (!payload || typeof payload.score !== "number") {
+      return NOT_FOUND;
+    }
+
+    // Revettr's composite score is already 0-100. Pass it through directly
+    // rather than re-mapping from tier, which would discard precision.
+    const score = Math.min(Math.max(Math.round(payload.score), 0), 100);
+
+    return {
+      found: true,
+      tier: payload.tier ?? null,
+      flags: Array.isArray(payload.flags) ? payload.flags : [],
+      jws: data.jws ?? null,
+      kid: data.kid ?? null,
+      jwksUrl: data.jwks_url ?? null,
+      revocationsUrl: data.revocations_url ?? null,
+      issuerDid: data.provider?.id ?? null,
+      attestationConfidence:
+        typeof data.attestation?.confidence === "number"
+          ? data.attestation.confidence
+          : 0,
+      score,
+    };
+  } catch {
+    return NOT_FOUND;
+  }
+}


### PR DESCRIPTION
Closes #2

## Summary

Adds `packages/trust/src/sources/revettr.ts` following the exact spec in issue #2:

- **Source file** at `packages/trust/src/sources/revettr.ts` mirroring the existing `moltbook.ts` / `base-chain.ts` / `erc8004.ts` pattern (typed `RevettrSignal` interface with `found`, domain fields, and a normalized `score` 0-100; async `queryRevettr` function; errors collapse to a `NOT_FOUND` signal instead of throwing).
- **TrustSignal score** is pulled directly from Revettr's composite score (`attestation.payload.score`) rather than re-mapped from `tier`, which would discard precision. `tier` and `flags` are still surfaced as first-class typed fields on the signal so the trust engine can weight them alongside the numeric score.
- **Env vars**: `REVETTR_API_KEY` (optional, forwarded as `x-api-key` when set), `REVETTR_API_URL` (defaults to `https://revettr.com`, overridable for self-hosted / test deployments).
- **Retry wrapper**: the fetch call goes through `packages/trust/src/utils/retry.fetchWithRetry` with `{ maxAttempts: 2, timeoutMs: 8000, baseDelayMs: 500 }`, matching the existing convention in `moltbook.ts`.
- **Registered** in `packages/trust/src/index.ts` alongside the other source exports.

## How it works

Calls `POST ${REVETTR_API_URL}/v1/attest` with a request body mapping paycrow input field names to Revettr field names:

| paycrow input | Revettr field |
|---|---|
| `wallet` | `wallet_address` |
| `domain` | `domain` |
| `ip` | `ip` |
| `company` | `company_name` |
| `solanaWallet` | `solana_wallet` |
| `xrplWallet` | `xrpl_wallet` |
| `bitcoinWallet` | `bitcoin_wallet` |
| `stellarWallet` | `stellar_wallet` |

Revettr runs all applicable signal groups (domain WHOIS / DNS / SSL, IP geolocation / VPN / datacenter detection, wallet on-chain history and counterparty analysis, sanctions screening against OFAC / EU / UN lists) and returns a signed JWS attestation envelope.

The source extracts:
- `attestation.payload.score` (0-100 composite) with clamping
- `attestation.payload.tier` (low | medium | high | critical)
- `attestation.payload.flags` (array of risk indicators)
- `attestation.confidence` (0-1 confidence on the attestation itself)
- `jws` (full compact JWS, RFC 7515, ES256, kid `revettr-attest-v1`)
- `jwks_url`, `revocations_url`, `provider.id` (issuer DID)

## Why Revettr

Revettr is the `compliance_risk` issuer in the A2A #1734 Trust Evidence Format RFC. The `compliance_risk` slot is the one no other agent trust provider currently fills: sanctions screening, wallet reputation across multiple chains, counterparty domain hygiene, IP reputation. That is the gap this PR closes for the paycrow trust layer.

- Discovery doc: https://revettr.com/.well-known/risk-check.json
- Live endpoint: https://revettr.com/v1/attest (free, 10 req/min per IP)
- RFC thread: https://github.com/a2aproject/A2A/discussions/1734

## Notes

- No paid-tier API key is required today. `REVETTR_API_KEY` is forward compatible for when the partner tier lands.
- JWS verification is intentionally not performed inside this source. The full JWS is attached to the returned `RevettrSignal` so paycrow can verify it out of band against the published JWKS if / when it wants stronger guarantees than the HTTPS channel to `revettr.com` provides. Doing the verification inside the source would pull a crypto dependency into `@paycrow/trust` just for one source, which felt heavier than the spec called for.
- Weight allocation across sources (Revettr, InsumerAPI via #1, and any others) is deliberately out of scope per the issue thread. Happy to do a follow up PR rebalancing `engine.ts` `WEIGHTS` once this and #1 both land.
- Wiring Revettr into `computeTrustScore` in `engine.ts` is also out of scope here. The source is fully registered in `src/index.ts` and ready to be composed. I did not touch the engine weights because that is a product decision and I did not want to front-run the maintainer on it.

## Test plan

Added `packages/trust/src/__tests__/sources/revettr.test.ts` with 15 vitest cases mirroring the `moltbook.test.ts` pattern:

- [x] Returns not-found when no input fields provided (no fetch fired)
- [x] Returns not-found on network error
- [x] Returns not-found on non-200 response
- [x] Returns not-found when attestation payload is missing
- [x] Returns not-found when payload score is missing
- [x] Passes composite score through unchanged
- [x] Extracts tier, flags, jws, kid, jwksUrl, revocationsUrl, issuerDid, confidence
- [x] Clamps score into 0-100 range (both directions)
- [x] Maps paycrow input field names to Revettr request body correctly
- [x] Forwards `REVETTR_API_KEY` as `x-api-key` header when set
- [x] Omits `x-api-key` header when unset
- [x] Explicit `apiKey` argument overrides env var
- [x] `REVETTR_API_URL` override changes endpoint
- [x] Optional non-EVM wallet fields (solana / xrpl / btc / stellar) pass through
- [x] Returns empty flags array when payload field is missing

Local run (`pnpm --filter @paycrow/trust test`):

```
Test Files  1 failed | 4 passed (5)
     Tests  79 passed (79)
```

The one failing test file is `base-chain.test.ts`, which is a pre-existing `@paycrow/core` workspace resolution failure on `upstream/main` unrelated to this PR (confirmed by running the test suite against `upstream/main` with no changes). All 15 new revettr tests pass, all 64 other pre-existing tests continue to pass.

## Files changed

- `packages/trust/src/sources/revettr.ts` (new, 195 lines)
- `packages/trust/src/__tests__/sources/revettr.test.ts` (new, 230 lines)
- `packages/trust/src/index.ts` (+1 line, adds source export)

No new dependencies. Native `fetch` (matches existing sources). No changes outside `packages/trust/src/`.